### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.3.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/neo4j/AbstractNeo4jConnection.java
+++ b/src/main/java/io/kestra/plugin/neo4j/AbstractNeo4jConnection.java
@@ -4,6 +4,7 @@ import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -12,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @NoArgsConstructor

--- a/src/main/java/io/kestra/plugin/neo4j/Batch.java
+++ b/src/main/java/io/kestra/plugin/neo4j/Batch.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.neo4j;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,7 +108,7 @@ public class Batch extends AbstractNeo4jConnection implements RunnableTask<Batch
 
             logger.debug("Starting query: {}", query);
 
-            try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)) {
+            try (InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
                 Flux<Integer> flowable;
                 AtomicLong count = new AtomicLong();
 

--- a/src/main/java/io/kestra/plugin/neo4j/Neo4jConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/neo4j/Neo4jConnectionInterface.java
@@ -1,9 +1,9 @@
 package io.kestra.plugin.neo4j;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.kestra.core.models.annotations.PluginProperty;
 
 public interface Neo4jConnectionInterface {
     @Schema(

--- a/src/main/java/io/kestra/plugin/neo4j/Query.java
+++ b/src/main/java/io/kestra/plugin/neo4j/Query.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.neo4j;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.AbstractMap;
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -35,7 +36,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @NoArgsConstructor
 @SuperBuilder
@@ -169,7 +169,7 @@ public class Query extends AbstractNeo4jConnection implements RunnableTask<Query
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
         try (
-            var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             Flux<Object> flowable = Flux
                 .create(

--- a/src/test/java/io/kestra/plugin/neo4j/BatchTest.java
+++ b/src/test/java/io/kestra/plugin/neo4j/BatchTest.java
@@ -1,11 +1,15 @@
 package io.kestra.plugin.neo4j;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -82,6 +86,15 @@ public class BatchTest {
             n1.put("position", UUID.randomUUID().toString());
             FileSerde.write(output, n1);
         }
-        return storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+        URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        // Read back ION and assert count + content
+        try (InputStream is = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, uri), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(is, result::add);
+            assertThat(result.size(), is(25000));
+        }
+
+        return uri;
     }
 }

--- a/src/test/java/io/kestra/plugin/neo4j/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/neo4j/RunnerTest.java
@@ -1,10 +1,11 @@
 package io.kestra.plugin.neo4j;
 
+import org.junit.jupiter.api.Test;
+
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- `Batch.java`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`/`InputStream`
- `Query.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `gradle.properties`: bump `kestraVersion` to `1.3.19`