### PR TITLE
refactor: rename deprecated retry property maxAttempt to maxAttempts

### DIFF
--- a/src/test/resources/sanity-checks/all_neo4j.yaml
+++ b/src/test/resources/sanity-checks/all_neo4j.yaml
@@ -31,7 +31,7 @@ tasks:
     retry:
       type: constant
       interval: PT5S
-      maxAttempt: 24
+      maxAttempts: 24
 
   - id: reset_db
     type: io.kestra.plugin.neo4j.Query


### PR DESCRIPTION
Renames the deprecated retry property maxAttempt to maxAttempts